### PR TITLE
Lay support groundwork for automated unit tests and port first test.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@
 # build
 __pycache__/
 **/*.pyc
+
+# test
+/tests/output

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 future
+pyyaml

--- a/tests/support.py
+++ b/tests/support.py
@@ -1,0 +1,40 @@
+import errno
+import os
+import shutil
+import sys
+from unittest import TestCase, main as testmain
+
+TEST_BASE = os.path.dirname(__file__)
+TEST_OUTPUT_DIR = os.path.join(TEST_BASE, "output")
+MIG_BASE = os.path.realpath(os.path.join(TEST_BASE, ".."))
+
+# All MiG related code will at some point include bits
+# from the mig module namespace. Rather than have this
+# knowledge spread through every test file, make the
+# sole responsbility of test files to find the support
+# file and configure the rest here.
+sys.path.append(MIG_BASE)
+
+# provision an output directory up-front
+try:
+    os.mkdir(TEST_OUTPUT_DIR)
+except EnvironmentError as e:
+    if e.errno == errno.EEXIST: pass # FileExistsError
+
+class MigTestCase(TestCase):
+    def __init__(self, *args):
+        super(MigTestCase, self).__init__(*args)
+        self._cleanup_paths = set()
+
+    def tearDown(self):
+        for path in self._cleanup_paths:
+            if os.path.isdir(path):
+                shutil.rmtree(path)
+            else:
+                os.remove(path)
+
+def temppath(relative_path, test_case=None):
+    tmp_path = os.path.join(TEST_OUTPUT_DIR, relative_path)
+    if isinstance(test_case, MigTestCase):
+        test_case._cleanup_paths.add(tmp_path)
+    return tmp_path

--- a/tests/test_mig_shared_serial.py
+++ b/tests/test_mig_shared_serial.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+
+import os
+import sys
+
+sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), ".")))
+
+from support import MigTestCase, temppath, testmain
+from mig.shared.serial import *
+
+class BasicSerial(MigTestCase):
+    BASIC_OBJECT = {'abc': 123, 'def': 'def', 'ghi': 42.0, 'accented': 'TéstÆøå'}
+
+    def test_pickle_string(self):
+        orig = BasicSerial.BASIC_OBJECT
+        data = loads(dumps(orig))
+        self.assertEqual(data, orig, "mismatch pickling string")
+
+    def test_pickle_file(self):
+        tmp_path = temppath("dummyserial.tmp", self)
+        orig = BasicSerial.BASIC_OBJECT
+        dump(orig, tmp_path)
+        data = load(tmp_path)
+        self.assertEqual(data, orig, "mismatch pickling string")
+
+if __name__ == '__main__':
+    testmain()


### PR DESCRIPTION
Add a support library intended for inclusion by every test file which sets the environment (e.g. sys.path) correctly for testing MiG code. This will allow tests to follow a standard structure of first find and include the support lib and then go about their business.

Expose an embellished TestCase class with niceties for our purposes. For now this amounts to enough wiring to cleanup temporary files created while executing the tests but worth doing up front to provide a leverage point.