### PR TITLE
Start covering the mig.shared.fileio write_chunk() function.

### DIFF
--- a/tests/support.py
+++ b/tests/support.py
@@ -1,6 +1,7 @@
 import errno
 import os
 import shutil
+import stat
 import sys
 from unittest import TestCase, main as testmain
 
@@ -21,20 +22,73 @@ try:
 except EnvironmentError as e:
     if e.errno == errno.EEXIST: pass # FileExistsError
 
+class FakeLogger:
+    CHANNELS = [
+        'error',
+    ]
+
+    def __init__(self):
+        self.channels_dict = FakeLogger.create_channels_dict()
+
+    def _append_as(self, channel, line):
+        self.channels_dict[channel].append(line)
+
+    def debug(self, line):
+        self._append_as('debug', line)
+
+    def error(self, line):
+        self._append_as('error', line)
+
+    def info(self, line):
+        self._append_as('info', line)
+
+    def warning(self, line):
+        self._append_as('warning', line)
+
+    @classmethod
+    def create_channels_dict(cls):
+        return dict(((channel, []) for channel in cls.CHANNELS))
+
 class MigTestCase(TestCase):
     def __init__(self, *args):
         super(MigTestCase, self).__init__(*args)
         self._cleanup_paths = set()
+        self._logger = None
 
     def tearDown(self):
+        self._logger = None
+
         for path in self._cleanup_paths:
             if os.path.isdir(path):
                 shutil.rmtree(path)
-            else:
+            elif os.path.exists(path):
                 os.remove(path)
+            else:
+                continue
 
-def temppath(relative_path, test_case=None):
+    @property
+    def logger(self):
+        if self._logger is None:
+            self._logger = FakeLogger()
+        return self._logger
+
+    def assertPathExists(self, relative_path):
+        assert(not os.path.isabs(relative_path)), "expected relative path within output folder"
+        absolute_path = os.path.join(TEST_OUTPUT_DIR, relative_path)
+        stat_result = os.stat(absolute_path)
+        if stat.S_ISDIR(stat_result.st_mode):
+            return "dir"
+        else:
+            return "file"
+
+def cleanpath(relative_path, test_case):
+    assert(isinstance(test_case, MigTestCase))
     tmp_path = os.path.join(TEST_OUTPUT_DIR, relative_path)
-    if isinstance(test_case, MigTestCase):
+    test_case._cleanup_paths.add(tmp_path)
+
+def temppath(relative_path, test_case, skip_clean=False):
+    assert(isinstance(test_case, MigTestCase))
+    tmp_path = os.path.join(TEST_OUTPUT_DIR, relative_path)
+    if not skip_clean:
         test_case._cleanup_paths.add(tmp_path)
     return tmp_path

--- a/tests/test_mig_shared_fileio.py
+++ b/tests/test_mig_shared_fileio.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+
+import binascii
+import os
+import sys
+
+sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), ".")))
+
+from support import MigTestCase, cleanpath, temppath, testmain
+
+import mig.shared.fileio
+fileio = mig.shared.fileio
+
+DUMMY_BYTES = binascii.unhexlify('DEADBEEF') # 4 bytes
+DUMMY_BYTES_LENGTH = 4
+DUMMY_FILE_WRITECHUNK = 'fileio/write_chunk'
+
+assert isinstance(DUMMY_BYTES, bytes)
+
+class TestFileioWriteChunk(MigTestCase):
+    def setUp(self):
+        self.tmp_path = temppath(DUMMY_FILE_WRITECHUNK, self, skip_clean=True)
+        cleanpath(os.path.dirname(DUMMY_FILE_WRITECHUNK), self)
+
+    def test_write_chunk_creates_directory(self):
+        fileio.write_chunk(self.tmp_path, DUMMY_BYTES, 0, self.logger)
+
+        path_kind = self.assertPathExists(DUMMY_FILE_WRITECHUNK)
+        self.assertEqual(path_kind, "file")
+
+    def test_write_chunk_store_bytes(self):
+        fileio.write_chunk(self.tmp_path, DUMMY_BYTES, 0, self.logger)
+
+        with open(self.tmp_path, 'rb') as file:
+            content = file.read(1024)
+            self.assertEqual(len(content), DUMMY_BYTES_LENGTH)
+            self.assertEqual(content[:], DUMMY_BYTES)
+
+    def test_write_chunk_store_bytes_at_offset(self):
+        offset = 3
+
+        fileio.write_chunk(self.tmp_path, DUMMY_BYTES, offset, self.logger)
+
+        with open(self.tmp_path, 'rb') as file:
+            content = file.read(1024)
+            self.assertEqual(len(content), DUMMY_BYTES_LENGTH + offset)
+            self.assertEqual(content[0:3], bytearray([0, 0, 0]), "expected a hole was left")
+            self.assertEqual(content[3:], DUMMY_BYTES)
+
+if __name__ == '__main__':
+    testmain()


### PR DESCRIPTION
Add tests exercising the write_chunk() function.

This is the first code being covered that makes use of logging which is handled via generic logging infrastructure and a logger argument throughout the codebase. Thus use this test as an excuse to include a FakeLogger in the support library which is made available to test cases via the standard test class and will support assertions against certain messages being produced by the code under test.